### PR TITLE
Correct broken homepage link

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "engines": {
     "node": ">= 0.9"
   },
-  "homepage": "http://terinjokes.github.io/gulp-uglify/",
+  "homepage": "https://github.com/terinjokes/gulp-uglify",
   "keywords": [
     "gulpplugin"
   ],


### PR DESCRIPTION
This pull request corrects a bad homepage link in the package.json. The homepage link shows up on the [plugin page](https://www.npmjs.org/package/gulp-uglify) and can be confusing. 
