### PR TITLE
Add caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ gulp.task('compress', function() {
 
 	Pass `false` to skip mangling names.
 
+  `cache`
+
+  Pass `true` to cache the processed output (including sourceMap). Caching is based on the file contents and the passed options object.
+
 - `output`
 
 	Pass an object if you wish to specify additional [output

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
     "gulp-util": "~2.2.14",
     "through2": "~0.4.0",
     "uglify-js": "~2.4.6",
-    "vinyl": "~0.2.3"
+    "vinyl": "~0.2.3",
+    "memory-cache": "0.0.5"
   },
   "devDependencies": {
-    "tape": "~2.4.2"
+    "tape": "~2.4.2",
+    "proxyquire": "^0.6.0"
   },
   "engines": {
     "node": ">= 0.9"

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,0 +1,80 @@
+'use strict';
+
+var test = require('tape'),
+    Vinyl = require('vinyl'),
+    cacheStub = {},
+    proxyquire = require('proxyquire'),
+    gulpUglify = proxyquire('../', {
+      'memory-cache': cacheStub
+    }),
+    uglifyjs = require('uglify-js');
+
+var testContentsInput = '"use strict"; (function(console, first, second) { console.log(first + second) }(5, 10))';
+
+var min = uglifyjs.minify(testContentsInput, {fromString: true});
+var testContentsExpected = min.code;
+var testMapExpected = min.map;
+
+var testFile = function(path) {
+  return new Vinyl({
+    cwd: "/home/terin/broken-promises/",
+    base: "/home/terin/broken-promises/test",
+    path: path || "/home/terin/broken-promises/test/test1.js",
+    contents: new Buffer(testContentsInput)
+  });
+};
+
+test('should not cache by default', function(t) {
+  t.plan(1);
+
+  var stream = gulpUglify();
+  stream.on('data', function() {
+    t.equal(cacheStub.size(), 0);
+  });
+
+  stream.write(testFile());
+});
+
+test('should cache if option is switched on', function(t) {
+  t.plan(2);
+
+  var options = {
+    cache: true
+  };
+  var file = testFile();
+  var stream = gulpUglify(options);
+
+  stream.on('data', function() {
+    t.equal(cacheStub.size(), 1);
+
+    t.deepEqual(cacheStub.get(file.path), {
+      raw: testContentsInput,
+      mangled: testContentsExpected,
+      map: testMapExpected,
+      options: options
+    });
+  });
+
+  stream.write(file);
+});
+
+
+test('should cache if option is switched on', function(t) {
+  t.plan(2);
+
+  cacheStub.clear();
+  cacheStub.debug(true);
+
+  var options = {
+    cache: true
+  };
+  var stream = gulpUglify(options);
+
+  stream.on('data', function() {
+    t.equal(cacheStub.size(), 1, 'There should be one file in the cache');
+  });
+
+  var file1 = testFile();
+  stream.write(file1);
+  stream.write(file1);
+});

--- a/test/general.js
+++ b/test/general.js
@@ -1,0 +1,16 @@
+'use strict';
+var test = require('tape'),
+    gulpUglify = require('../');
+
+test('should not alter given options object', function(t) {
+  t.plan(1);
+
+  var myOptionsObject = {
+    fromString: true
+  };
+  gulpUglify(myOptionsObject);
+
+  t.deepEqual(myOptionsObject, {
+    fromString: true
+  });
+});


### PR DESCRIPTION
This adds caching to gulp-uglify.
We needed this because of the amount of JS files and delta compiling to speed up our dev environment.
