### PR TITLE
feat(*): restores the output message shown if Uglify throws an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ module.exports = function(opt) {
 			if (lineStr) {
 				lineStr = lineStr.substr(Math.max(error.col - lineOffsetSize, 0), lineOffsetSize * 2);
 				console.log(lineStr.replace(tabs, SPACE));
-				console.log(Array(lineOffsetSize - 1 + error.col).join(SPACE) + '^');
+				console.log(Array(error.col).join('–') + '^');
 			}
 		}
 	}


### PR DESCRIPTION
I like the error output shown if the Uglify lib fails to minify a given file. Since issue #25, errors are propagated to Gulp and the message is no longer printed.

The changes will restore the error output and add two lines of code from the failed file to give a better context on where is the error.
