### PR TITLE
Don't mutate the input file.

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,13 +70,14 @@ module.exports = function(opt) {
 				return callback(err);
 			}
 			
-			file.contents = mangled.code;
+			var result = file.clone();
+			result.contents = mangled.code;
 
-			if (file.sourceMap) {
-				applySourceMap(file, mangled.map);
+			if (result.sourceMap) {
+				applySourceMap(result, mangled.map);
 			}
 
-			callback(null, file);
+			callback(null, result);
 		});
 	}
 


### PR DESCRIPTION
Return a changed copy of input file instead of mutating the input file itself. Fixes #62
