### PR TITLE
Use uglify@2.4.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "deepmerge": ">=0.2.7 <0.3.0-0",
     "gulp-util": ">=3.0.0 <4.0.0-0",
     "through2": ">=0.6.1 <1.0.0-0",
-    "uglify-js": "2.4.15",
+    "uglify-js": "2.4.16",
     "vinyl-sourcemaps-apply": ">=0.1.1 <0.2.0-0"
   },
   "devDependencies": {


### PR DESCRIPTION
I'm hoping you'll consider publishing a release with Uglify 2.4.16.  There are a [number of fixes](https://github.com/mishoo/UglifyJS2/compare/v2.4.15...v2.4.16) in this release.  I'm looking for this one in particular: https://github.com/mishoo/UglifyJS2/commit/62bda71c853e844f0477873397ae7ae211bc7dc8.