### PR TITLE
Add ability to pass uglify instance as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,19 @@ gulp.task('compress', function() {
 		current node and the current comment and are expected to return either
 		`true` or `false`.
 
+- `uglify`
+	If you want to use a different version of uglify, you can pass your own instance of uglify as the uglify option:
+
+	```javascript
+	var uglify = require('gulp-uglify');
+
+	gulp.task('compress', function() {
+	  gulp.src('lib/*.js')
+	    .pipe(uglify({ uglify: require('uglify-js') }))
+	    .pipe(gulp.dest('dist'))
+	});
+	```
+
 You can also pass the `uglify` function any of the options [listed
 here](https://github.com/mishoo/UglifyJS2#the-simple-way) to modify
 UglifyJS's behavior.

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 var through = require('through2'),
-	uglify = require('uglify-js'),
 	merge = require('deepmerge'),
 	PluginError = require('gulp-util/lib/PluginError'),
 	applySourceMap = require('vinyl-sourcemaps-apply'),
@@ -11,7 +10,7 @@ function minify(file, options) {
 	var mangled;
 
 	try {
-		mangled = uglify.minify(String(file.contents), options);
+		mangled = options.uglify.minify(String(file.contents), options);
 		mangled.code = new Buffer(mangled.code.replace(reSourceMapComment, ''));
 		return mangled;
 	} catch (e) {
@@ -24,6 +23,8 @@ function setup(opts) {
 		fromString: true,
 		output: {}
 	});
+
+	options.uglify = options.uglify || require('uglify-js');
 
 	if (options.preserveComments === 'all') {
 		options.output.comments = true;

--- a/test/err.js
+++ b/test/err.js
@@ -2,7 +2,7 @@
 var test = require('tape'),
 		Vinyl = require('vinyl'),
 		gulpUglify = require('../');
-	
+
 var testContentsInput = 'function errorFunction(error)\n{';
 var testOkContentsInput = '"use strict"; (function(console, first, second) { console.log(first + second) }(5, 10))';
 
@@ -65,4 +65,21 @@ test('shouldn\'t blow up when given output options', function(t) {
 
 	stream.write(testFile2);
 	stream.end();
+});
+
+test('should fail with misconfigured uglify option', function(t) {
+  t.plan(1);
+
+  var stream = gulpUglify({ uglify: {} });
+
+	stream.on('data', function() {
+		t.fail('we shouldn\'t have gotten here');
+	});
+
+	stream.on('error', function(e) {
+		t.ok(e instanceof Error, 'argument should be of type error');
+	});
+
+  stream.write(testFile1);
+  stream.end();
 });

--- a/test/minify.js
+++ b/test/minify.js
@@ -3,7 +3,7 @@ var test = require('tape'),
 		Vinyl = require('vinyl'),
 		gulpUglify = require('../'),
 		uglifyjs = require('uglify-js');
-	
+
 var testContentsInput = '"use strict"; (function(console, first, second) { console.log(first + second) }(5, 10))';
 var testContentsExpected = uglifyjs.minify(testContentsInput, {fromString: true}).code;
 
@@ -33,4 +33,17 @@ test('should minify files', function(t) {
 
 	stream.write(testFile1);
 	stream.end();
+});
+
+test('should minify files with uglify option', function(t) {
+  t.plan(1);
+
+  var stream = gulpUglify({ uglify: uglifyjs });
+
+  stream.on('data', function(newFile) {
+    t.equals(String(newFile.contents), testContentsExpected);
+  });
+
+  stream.write(testFile1);
+  stream.end();
 });


### PR DESCRIPTION
The same idea, as [gulp-jade](https://github.com/phated/gulp-jade#options) uses:
```javascript
var uglify = require('gulp-uglify');

gulp.task('compress', function() {
  gulp.src('lib/*.js')
    .pipe(uglify({ uglify: require('uglify-js') }))
    .pipe(gulp.dest('dist'))
});
```