### PR TITLE
Update UglifyJS to v2.4.0 and bump gulp-uglify to 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # gulp-uglify changelog
 
+## 1.2.1
+
+- Update UglifyJS to 2.4.20 since [v2.4.18 introduced a breaking change](https://github.com/mishoo/UglifyJS2/issues/673).
+
 ## 1.2.0
 
 - Update dependencies, including UglifyJS to 2.4.19.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "deap": ">=1.0.0 <2.0.0-0",
     "gulp-util": ">=3.0.0 <4.0.0-0",
     "through2": ">=0.6.1 <1.0.0-0",
-    "uglify-js": "2.4.19",
+    "uglify-js": "2.4.20",
     "vinyl-sourcemaps-apply": ">=0.1.1 <0.2.0-0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-uglify",
   "description": "Minify files with UglifyJS.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "Terin Stock <terinjokes@gmail.com>",
   "bugs": "https://github.com/terinjokes/gulp-uglify/issues",
   "dependencies": {


### PR DESCRIPTION
UglifyJS v2.4.18 introduced a [breaking change](https://github.com/mishoo/UglifyJS2/issues/673) that was [fixed in v2.4.20](https://github.com/mishoo/UglifyJS2/issues/673#issuecomment-92411752).

This commit updates gulp-uglify to use UglifyJS v2.4.20 (instead of v2.4.19) and bumps gulp-uglify to v1.2.1 as a result.

Fixes https://github.com/terinjokes/gulp-uglify/issues/98