### PR TITLE
Require uglify-js as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
     "deap": ">=1.0.0 <2.0.0-0",
     "gulp-util": ">=3.0.0 <4.0.0-0",
     "through2": ">=0.6.1 <1.0.0-0",
-    "uglify-js": "2.4.19",
     "vinyl-sourcemaps-apply": ">=0.1.1 <0.2.0-0"
+  },
+  "peerDependencies": {
+    "uglify-js": "~2.4.0"
   },
   "devDependencies": {
     "argg": "0.0.1",


### PR DESCRIPTION
See http://blog.nodejs.org/2013/02/07/peer-dependencies/

By defining `uglify-js` as a peer dependency, we can get rid of the maintenance burden of keeping up with UglifyJS releases and cluttering our own release cycle.

By default, `npm install` will install the latest version of `uglify-js` alongside `gulp-uglify`, but users will also be able to explicitly set which version of `uglify-js` to use without any additional code.

Fixes https://github.com/terinjokes/gulp-uglify/issues/98