### PR TITLE
Fix a typo in the sourcemap test

### DIFF
--- a/test/sourcemap.js
+++ b/test/sourcemap.js
@@ -10,7 +10,7 @@ var testContents1Input = '(function(first, second) {\n    console.log(first + se
 var testContents1Expected = uglifyjs.minify(testContents1Input, {fromString: true}).code;
 var testContents2Input = '(function(alert) {\n    alert(5);\n}(alert));\n';
 var testContents2Expected = uglifyjs.minify(testContents2Input, {fromString: true}).code;
-var testConcatExpected = uglifyjs.minify(testContents1Expected + testContents2Input, {fromString: true}).code;
+var testConcatExpected = uglifyjs.minify(testContents1Input + '\n' + testContents2Input, {fromString: true}).code;
 
 test('should minify files', function(t) {
 	t.plan(11);


### PR DESCRIPTION
Fix a small type, it should be 'input' instead of 'expected'.
And add `\n` between them because this is what `concat()` does.