### PR TITLE
Catch uglifys warning messages

### DIFF
--- a/minifier.js
+++ b/minifier.js
@@ -49,8 +49,13 @@ module.exports = function (opts, uglify) {
       // the warn_function passes a format string as first argument
       // - we override that and add the filename to the arguments
       var args = Array.prototype.slice.call(arguments);
-      args[0] = 'gulp-uglify: %s: %s';
-      args.splice(1, 0, (file.base && file.path) ? file.relative : file.path);
+      var filePath = (file.base && file.path) ? file.relative : file.path;
+      if(args[0] === 'WARN: %s') {
+        args[0] = 'gulp-uglify: %s: %s';
+        args.splice(1, 0, filePath);
+      } else {
+        args.unshift( 'gulp-uglify:', filePath );
+      }
       log.apply(null, args);
     };
     var options = setup(opts || {});

--- a/minifier.js
+++ b/minifier.js
@@ -45,16 +45,16 @@ function setup(opts) {
 
 module.exports = function (opts, uglify) {
   function minify(file, encoding, callback) {
-    var overriddenError = function overriddenError(){
+    var overriddenError = function overriddenError() {
       // the warn_function passes a format string as first argument
       // - we override that and add the filename to the arguments
       var args = Array.prototype.slice.call(arguments);
       var filePath = (file.base && file.path) ? file.relative : file.path;
-      if(args[0] === 'WARN: %s') {
+      if (args[0] === 'WARN: %s') {
         args[0] = 'gulp-uglify: %s: %s';
         args.splice(1, 0, filePath);
       } else {
-        args.unshift( 'gulp-uglify:', filePath );
+        args.unshift('gulp-uglify:', filePath);
       }
       log.apply(null, args);
     };

--- a/minifier.js
+++ b/minifier.js
@@ -45,6 +45,14 @@ function setup(opts) {
 
 module.exports = function (opts, uglify) {
   function minify(file, encoding, callback) {
+    var overriddenError = function overriddenError(){
+      // the warn_function passes a format string as first argument
+      // - we override that and add the filename to the arguments
+      var args = Array.prototype.slice.call(arguments);
+      args[0] = 'gulp-uglify: %s: %s';
+      args.splice(1, 0, (file.base && file.path) ? file.relative : file.path);
+      log.apply(null, args);
+    };
     var options = setup(opts || {});
 
     if (file.isNull()) {
@@ -62,7 +70,10 @@ module.exports = function (opts, uglify) {
     var originalContents = String(file.contents);
 
     var mangled = trycatch(function () {
+      var orgError = console.error;
+      console.error = overriddenError;
       var m = uglify.minify(String(file.contents), options);
+      console.error = orgError;
       m.code = new Buffer(m.code.replace(reSourceMapComment, ''));
       return m;
     }, createError.bind(null, file));


### PR DESCRIPTION
The uglify 'warning' option throws useful messages to console.error. Unfortunately, it does so without filename information. By capturing the console.error call (originating from tool/node.js) and passing the arguments into fancy-log, we fix that.

Note that I'm not thrilled about patching `console.error`, but feel that actually getting the relevant file name in the output justifies the transgression.

Fixes #163
