### PR TITLE
feat(nameCache) Retain the nameCache option as an object reference

### DIFF
--- a/lib/minify.js
+++ b/lib/minify.js
@@ -11,12 +11,25 @@ module.exports = function(uglify, log) {
       opts = {};
     }
 
-    return defaultsDeep(
+    //The nameCache option should be a mutable reference. Do not clone it.
+	var nameCache;
+    if (opts.nameCache !== undefined) {
+    	nameCache = opts.nameCache;
+    	delete opts.nameCache;
+    }
+
+    var defaults = defaultsDeep(
       {
         output: {}
       },
       opts
     );
+
+    if (nameCache !== undefined) {
+    	defaults.nameCache = nameCache;
+    }
+
+    return defaults;
   }
 
   return function(opts) {

--- a/test/minify.js
+++ b/test/minify.js
@@ -56,6 +56,28 @@ describe('minify', function() {
     });
   });
 
+  it('should retain the nameCache option as a mutable reference', function() {
+    var uglify = td.object(['minify']);
+    var logger = td.object(['warn']);
+
+    var nameCache = {};
+    td.when(uglify.minify(td.matchers.anything(), td.matchers.anything()))
+      .thenDo(function(files, options) {
+        options.nameCache['unmangled'] = 'mangled';
+        return { code: 'foobar' };
+      });
+
+    var subject = minify(uglify, logger)({ nameCache: nameCache });
+    subject(this.testFile);
+
+    assert.equal(nameCache['unmangled'], 'mangled');
+
+    td.verify(logger.warn(), {
+      times: 0,
+      ignoreExtraArgs: true
+    });
+  });
+
   it('string argument should cause warning', function() {
     var uglify = td.object(['minify']);
     var logger = td.object(['warn']);
@@ -86,4 +108,5 @@ describe('minify', function() {
     assert.ok(Buffer.isBuffer(file.contents));
     assert.equal(String(file.contents), 'foobar');
   });
+
 });


### PR DESCRIPTION
I have a use case where I need to pipe to gulp-minify with different options for different files, but I need a common nameCache.  

This could be a breaking change, but I think it more accurately mirrors the interface provided by uglify itself.