### PR TITLE
Upgrade to lodash 4.17.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "gulplog": "^1.0.0",
     "has-gulplog": "^0.1.0",
-    "lodash": "^4.13.1",
+    "lodash": "^4.17.11",
     "make-error-cause": "^1.1.1",
     "safe-buffer": "^5.1.2",
     "through2": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-uglify",
   "description": "Minify files with UglifyJS.",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": "Terin Stock <terinjokes@gmail.com>",
   "bugs": "https://github.com/terinjokes/gulp-uglify/issues",
   "dependencies": {


### PR DESCRIPTION
There are known vulnerabilities in versions of Lodash lower than 4.17.11

https://nvd.nist.gov/vuln/detail/CVE-2018-16487
https://nvd.nist.gov/vuln/detail/CVE-2018-3721

Upgrading to 4.17.11 resolves these vulnerabilities