### PR TITLE
include the file that failed minification in the error message

### DIFF
--- a/lib/minify.js
+++ b/lib/minify.js
@@ -55,7 +55,7 @@ module.exports = function(uglify, log) {
       if (!mangled || mangled.error) {
         throw createError(
           file,
-          'unable to minify JavaScript',
+          'unable to minify JavaScript: ' + file.relative,
           mangled && mangled.error
         );
       }


### PR DESCRIPTION
This might be overkill a lot of the time, since figuring out which file has the problem probably won't take that long if your PR is reasonably sized, but at the same time, it's easy to report which file has the problem, so why not do it?